### PR TITLE
Add minimum working Elixir/Erlang version in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: elixir
-elixir:
-  - '1.10'
-otp_release:
-  - '23.0.4'
+
+matrix:
+  include:
+  - elixir: "1.10.4"
+    otp_release: "23.0.4"
+  - elixir: "1.9.4"
+    otp_release: "22.3.4"
 
 env:
   global:

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Honeylixir.MixProject do
     [
       app: :honeylixir,
       version: "0.3.0",
-      elixir: "~> 1.10",
+      elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs(),


### PR DESCRIPTION
This PR ensures Travis CI also includes the minimum module requirements of Elixir 1.9.x and Erlang/OTP 22.x.

All these commands works without issues.
```
$ asdf install
$ mix deps.get
$ mix compile
$ mix test
```